### PR TITLE
reduce less on killer moves

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -83,6 +83,11 @@ public:
 
     Killers() { killers[0] = NO_MOVE, killers[1] = NO_MOVE; };
 
+    Move operator[](int index)
+    {
+        return killers[index];
+    }
+
     void insert(Move move);
     void clear() { killers[0] = NO_MOVE, killers[1] = NO_MOVE; };
 

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -119,7 +119,7 @@ void MovePicker::score(SearchStack *ss, ThreadData &thread_data, Move tt_move, b
             // check killer moves
             for (int j = 0; j < ss->killers.size(); ++j)
             {
-                if (move_list.moves[i] == ss->killers.killers[j])
+                if (move_list.moves[i] == ss->killers[j])
                 {
                     move_list.moves[i].score = MAX_KILLERS - j;
                 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -589,6 +589,9 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
         if (cutnode)
             reduction += 1;
 
+        if (curr_move == ss->killers[0] || curr_move == ss->killers[1])
+            --reduction;
+
         if (is_quiet)
             reduction -= get_quiet_history_score(ss, thread_data, curr_move) / 10'000;
 


### PR DESCRIPTION
Elo   | 2.31 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 40488 W: 10377 L: 10108 D: 20003
Penta | [276, 4727, 10020, 4894, 327]
https://chess.aronpetkovski.com/test/1654/

BENCH: 2273946