### PR TITLE
added material scaling

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -894,5 +894,11 @@ int evaluate(const Board &board, std::vector<Accumulator> &accumulators, SearchS
         accumulators[starting + 1].make_move(ss_copy->board, ss_copy->move_played);
     }
 
-    return NNUE::eval(accumulators[ending], board.side_to_move);
+    int eval = NNUE::eval(accumulators[ending], board.side_to_move);
+
+    int phase = 3 * count_bits(board.pieces[BITBOARD_PIECES::KNIGHT]) + 3 * count_bits(board.pieces[BITBOARD_PIECES::BISHOP]) + 5 * count_bits(board.pieces[BITBOARD_PIECES::ROOK]) + 10 * count_bits(board.pieces[BITBOARD_PIECES::QUEEN]);
+
+    eval = eval * (206 + phase) / 256;
+
+    return eval;
 }


### PR DESCRIPTION
Elo   | 3.29 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19562 W: 5028 L: 4843 D: 9691
Penta | [150, 2189, 4877, 2456, 109]
https://chess.aronpetkovski.com/test/1699/

BENCH: 2534145

