### PR TITLE
added prefetching to the TT

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -168,6 +168,9 @@ int Searcher::quiescence_search(int alpha, int beta, SearchStack *ss)
         (ss + 1)->updated_accumulator = false;
         (ss)->move_played = curr_move;
 
+        // prefetch the TT entry
+        transposition_table.prefetch(copy);
+
         int current_score = -quiescence_search<inPV>(-beta, -alpha, ss + 1);
 
         if (stopped)
@@ -465,8 +468,6 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
         int new_depth = depth - 1;
         int extensions = 0;
 
-        // std::cout << copy.fen();
-
         // Singular Extensions: If a TT move exists and its score is accurate enough
         // (close enough in depth), we perform a reduced-depth search with the TT
         // move excluded to see if any other moves can beat it.
@@ -539,6 +540,9 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
 
         // we can update threefold
         game_history.push_back(copy.hash);
+
+        // prefetch the TT entry
+        transposition_table.prefetch(copy);
 
         int reduction = 0;
         int current_score;

--- a/src/transposition_table.cpp
+++ b/src/transposition_table.cpp
@@ -104,9 +104,15 @@ void TranspositionTable::resize(uint64_t size)
     hashtable.resize(tt_entry_count, TT_Entry());
 }
 
+void TranspositionTable::prefetch(const Board &board)
+{
+    const uint64_t hash_location = index(board);
+    __builtin_prefetch(&hashtable[hash_location]);
+}
+
 void TranspositionTable::insert(const Board &board, Move best_move, int16_t best_score, int16_t static_eval, uint8_t depth, uint8_t ply, uint32_t age, uint8_t flag)
 {
-    uint64_t hash_location = board.hash % hashtable.size();
+    uint64_t hash_location = index(board);
 
     // TODO: ADD BETTER TT REPLACEMENT ALGO
     hashtable[hash_location].hash = board.hash;
@@ -149,7 +155,7 @@ void TranspositionTable::insert(const Board &board, Move best_move, int16_t best
 
 TT_Entry &TranspositionTable::probe(const Board &board)
 {
-    uint64_t hash_location = board.hash % hashtable.size();
+    uint64_t hash_location = index(board);
 
     return hashtable[hash_location];
 }

--- a/src/transposition_table.h
+++ b/src/transposition_table.h
@@ -41,10 +41,14 @@ public:
     TranspositionTable(uint64_t size);
     // clears the transposition table
     void resize(uint64_t size);
+    void prefetch(const Board &board);
     void insert(const Board &board, Move best_move, int16_t best_score, int16_t static_eval, uint8_t depth, uint8_t ply, uint32_t age, uint8_t flag);
     void clear();
     // prints out permille what percent of the hashtable is full
     int hash_full();
     // bool contains(uint64_t hash);
     TT_Entry &probe(const Board &board);
+
+private:
+    inline int index(const Board &board) { return board.hash % hashtable.size(); };
 };


### PR DESCRIPTION
Elo   | 3.02 +- 2.46 (95%)
SPRT  | 1.0+0.01s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 29552 W: 9194 L: 8937 D: 11421
Penta | [616, 3052, 7242, 3191, 675]
https://chess.aronpetkovski.com/test/1931/

bench: 2099601