### PR TITLE
Tt replacement

### DIFF
--- a/src/transposition_table.cpp
+++ b/src/transposition_table.cpp
@@ -118,8 +118,9 @@ void TranspositionTable::insert(const Board &board, Move best_move, int16_t best
 
     // replacement policy
     if (board.hash == entry.hash && flag != BOUND::EXACT && depth <= entry.depth - 4)
+        return;
 
-        entry.hash = board.hash;
+    entry.hash = board.hash;
     entry.score = best_score;
     entry.static_eval = static_eval;
     entry.depth = depth;


### PR DESCRIPTION
Elo   | 5.71 +- 3.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12654 W: 3332 L: 3124 D: 6198
Penta | [44, 1465, 3156, 1563, 99]
https://chess.aronpetkovski.com/test/2302/