### PR TITLE
added 50mr scaling to NNUE

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -894,13 +894,7 @@ int evaluate(const Board &board, std::vector<Accumulator> &accumulators, SearchS
         accumulators[starting + 1].make_move(ss_copy->board, ss_copy->move_played);
     }
 
-    int eval = NNUE::eval(board, accumulators[ending]);
-
-    int phase = 3 * count_bits(board.pieces[BITBOARD_PIECES::KNIGHT]) + 3 * count_bits(board.pieces[BITBOARD_PIECES::BISHOP]) + 5 * count_bits(board.pieces[BITBOARD_PIECES::ROOK]) + 10 * count_bits(board.pieces[BITBOARD_PIECES::QUEEN]);
-
-    eval = eval * (206 + phase) / 256;
-
-    return eval;
+    return evaluate(board, accumulators[ending]);
 }
 
 int evaluate(const Board &board, const Accumulator &accumulator)
@@ -910,6 +904,8 @@ int evaluate(const Board &board, const Accumulator &accumulator)
     int phase = 3 * count_bits(board.pieces[BITBOARD_PIECES::KNIGHT]) + 3 * count_bits(board.pieces[BITBOARD_PIECES::BISHOP]) + 5 * count_bits(board.pieces[BITBOARD_PIECES::ROOK]) + 10 * count_bits(board.pieces[BITBOARD_PIECES::QUEEN]);
 
     eval = eval * (206 + phase) / 256;
+
+    eval = eval * (200 - board.fifty_move_counter) / 200;
 
     return eval;
 }


### PR DESCRIPTION
Elo   | 6.15 +- 3.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11082 W: 2865 L: 2669 D: 5548
Penta | [39, 1180, 2913, 1364, 45]
https://chess.aronpetkovski.com/test/2871/

BENCH: 2125849