### PR TITLE
speedup to attacked squares

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -258,16 +258,12 @@ bool Board::is_square_attacked(uint8_t square, uint8_t side_attacking) const
 
     // attacks by sliding pieces
     uint64_t blocking_pieces = blockers();
-    // attacked by bishop
-    if (get_bishop_attacks(square, blocking_pieces) & (colors[side_attacking] & pieces[BISHOP]))
+    // diagonal attacks from bishop or queens
+    if (get_bishop_attacks(square, blocking_pieces) & (colors[side_attacking] & (pieces[BISHOP] | pieces[QUEEN])))
         return true;
 
-    // attacked by rooks
-    if (get_rook_attacks(square, blocking_pieces) & (colors[side_attacking] & pieces[ROOK]))
-        return true;
-
-    // attacked by queens
-    if (get_queen_attacks(square, blocking_pieces) & (colors[side_attacking] & pieces[QUEEN]))
+    // straight attacks from rooks or queens
+    if (get_rook_attacks(square, blocking_pieces) & (colors[side_attacking] & (pieces[ROOK] | pieces[QUEEN])))
         return true;
 
     return false;


### PR DESCRIPTION
Elo   | 4.44 +- 2.98 (95%)
SPRT  | 1.0+0.01s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21894 W: 6743 L: 6463 D: 8688
Penta | [466, 2489, 4870, 2543, 579]
https://chess.aronpetkovski.com/test/3130/

BENCH: 3278700