### PR TITLE
since we want positive moves, take overwhelmingly good moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -349,7 +349,7 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
 
         // scores moves to order them
         MovePicker move_picker(captures_and_promotions);
-        move_picker.score(ss, thread_data, tt_move, has_tt_entry, -107);
+        move_picker.score(ss, thread_data, tt_move, has_tt_entry, 107);
 
         while (move_picker.has_next())
         {


### PR DESCRIPTION
Elo   | 2.66 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32594 W: 8407 L: 8157 D: 16030
Penta | [151, 3700, 8369, 3902, 175]
https://chess.aronpetkovski.com/test/3177/

BENCH: 3322943