### PR TITLE
Reduce tt entry size

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <iomanip>
 
+__extension__ typedef unsigned __int128 uint128_t;
+
 // toss random imports and shit in here
 #define NAME "   _____                   _          _   \n  / ____|                 | |        | |  \n | (___  _ __   __ _  __ _| |__   ___| |_ \n  \\___ \\| '_ \\ / _` |/ _` | '_ \\ / _ \\ __|\n  ____) | |_) | (_| | (_| | | | |  __/ |_ \n |_____/| .__/ \\__,_|\\__, |_| |_|\\___|\\__|\n        | |           __/ |               \n        |_|          |___/                "
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -91,12 +91,12 @@ int Searcher::quiescence_search(int alpha, int beta, SearchStack *ss)
     // we check if the TT has seen this before
     TT_Entry tt_entry = transposition_table.probe(board);
 
-    bool tt_hit = !ss->exclude_tt_move && tt_entry.hash == board.hash && tt_entry.flag() != BOUND::NONE;
+    bool tt_hit = !ss->exclude_tt_move && tt_entry.hash_equals(board) && tt_entry.flag() != BOUND::NONE;
     Move tt_move = ss->exclude_tt_move ? NO_MOVE : tt_entry.best_move;
 
     // tt cutoff
     // if the tt_entry matches, we can use the score, and the depth is the same or greater, we can just cut the search short
-    if (!inPV && !ss->exclude_tt_move && tt_entry.hash == board.hash && tt_entry.can_use_score(alpha, beta))
+    if (!inPV && !ss->exclude_tt_move && tt_entry.hash_equals(board) && tt_entry.can_use_score(alpha, beta))
     {
         return tt_entry.usable_score(ss->ply);
     }
@@ -249,7 +249,7 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
 
     // tt cutoff
     // if the tt_entry matches, we can use the score, and the depth is the same or greater, we can just cut the search short
-    if (!inPV && !ss->exclude_tt_move && tt_entry.hash == board.hash && tt_entry.can_use_score(alpha, beta) && tt_entry.depth >= depth)
+    if (!inPV && !ss->exclude_tt_move && tt_entry.hash_equals(board) && tt_entry.can_use_score(alpha, beta) && tt_entry.depth >= depth)
     {
         return tt_entry.usable_score(ss->ply);
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -241,11 +241,11 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
     // bool inPV = beta - alpha > 1;
 
     // we check if the TT has seen this before
-    TT_Entry &tt_entry = transposition_table.probe(board);
+    TT_Entry tt_entry = transposition_table.probe(board);
 
-    bool tt_hit = !ss->exclude_tt_move && tt_entry.hash == board.hash && tt_entry.flag() != BOUND::NONE;
+    bool tt_hit = !ss->exclude_tt_move && tt_entry.hash_equals(board) && tt_entry.flag() != BOUND::NONE;
     Move tt_move = ss->exclude_tt_move ? NO_MOVE : tt_entry.best_move;
-    bool has_tt_move = tt_entry.flag() != BOUND::NONE && tt_entry.hash == board.hash && tt_entry.best_move != NO_MOVE;
+    bool has_tt_move = tt_entry.flag() != BOUND::NONE && tt_entry.hash_equals(board) && tt_entry.best_move != NO_MOVE;
 
     // tt cutoff
     // if the tt_entry matches, we can use the score, and the depth is the same or greater, we can just cut the search short

--- a/src/transposition_table.cpp
+++ b/src/transposition_table.cpp
@@ -14,7 +14,7 @@ TT_Entry::TT_Entry()
 
 TT_Entry::TT_Entry(const Board &board, Move best_move, int16_t score, int16_t static_eval, uint8_t depth, uint8_t ply, uint32_t age, uint8_t flag)
 {
-    this->hash = board.hash;
+    this->hash = static_cast<uint16_t>(board.hash);
     this->best_move = best_move;
     this->static_eval = static_eval;
     this->depth = depth;
@@ -34,8 +34,6 @@ TT_Entry::TT_Entry(const Board &board, Move best_move, int16_t score, int16_t st
     {
         this->score = score;
     }
-
-    // std::cout << this->score << "\n";
 
     // basically mod 64
     uint8_t modular_age = age & 63;
@@ -120,7 +118,8 @@ void TranspositionTable::insert(const Board &board, Move best_move, int16_t best
     if (board.hash == entry.hash && flag != BOUND::EXACT && depth <= entry.depth - 4)
         return;
 
-    entry.hash = board.hash;
+    // Takes the last 16 bits
+    entry.hash = static_cast<uint16_t>(board.hash);
     entry.score = best_score;
     entry.static_eval = static_eval;
     entry.depth = depth;

--- a/src/transposition_table.cpp
+++ b/src/transposition_table.cpp
@@ -115,7 +115,7 @@ void TranspositionTable::insert(const Board &board, Move best_move, int16_t best
     TT_Entry &entry = hashtable[hash_location];
 
     // replacement policy
-    if (board.hash == entry.hash && flag != BOUND::EXACT && depth <= entry.depth - 4)
+    if (entry.hash_equals(board) && flag != BOUND::EXACT && depth <= entry.depth - 4)
         return;
 
     // Takes the last 16 bits

--- a/src/transposition_table.h
+++ b/src/transposition_table.h
@@ -4,14 +4,11 @@
 #include "board.h"
 #include "move.h"
 
-// allows us to convert mate scores into a usable format that we can use to detect checkmates
-int ttscore_to_score(uint16_t tt_score, int ply);
-
 class TT_Entry
 {
 public:
-    // hash of the board state
-    uint64_t hash;
+    // last 16 bits of the hash
+    uint16_t hash;
     Move best_move;
     int16_t score;
     uint8_t depth;
@@ -25,6 +22,7 @@ public:
     uint8_t flag() const;
     // moded to 64
     uint8_t age() const;
+    inline bool hash_equals(const Board &board) const { return static_cast<uint16_t>(board.hash) == hash; }
     bool can_use_score(int alpha, int beta) const;
     // converts the score into the TT into a score that can used to detect and play mates
     int16_t usable_score(int ply) const;
@@ -49,5 +47,5 @@ public:
     TT_Entry &probe(const Board &board);
 
 private:
-    inline size_t index(const Board &board) { return board.hash % hashtable.size(); };
+    inline size_t index(const Board &board) { return (static_cast<uint128_t>(board.hash) * static_cast<uint128_t>(hashtable.size())) >> 64; };
 };


### PR DESCRIPTION
Elo   | 15.90 +- 5.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 3958 W: 1110 L: 929 D: 1919
Penta | [8, 388, 1021, 539, 23]
https://chess.aronpetkovski.com/test/3271/

BENCH: 3253977