### PR TITLE
Nmp eval guard2

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -297,7 +297,7 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
     (ss + 1)->killers.clear();
 
     // applies null move pruning
-    if (!(ss - 1)->null_moved && !inPV && !ss->exclude_tt_move && !ss->in_check && !board.only_pawns(board.side_to_move) && ss->static_eval >= beta)
+    if (!(ss - 1)->null_moved && !inPV && !ss->exclude_tt_move && !ss->in_check && !board.only_pawns(board.side_to_move) && eval >= beta && ss->static_eval >= beta - 20 * depth + 400)
     {
         int r = std::min((eval - beta) / 200, 6) + depth / 3 + 4;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -297,7 +297,7 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
     (ss + 1)->killers.clear();
 
     // applies null move pruning
-    if (!(ss - 1)->null_moved && !inPV && !ss->exclude_tt_move && !ss->in_check && !board.only_pawns(board.side_to_move) && eval >= beta && ss->static_eval >= beta - 20 * depth + 400)
+    if (!(ss - 1)->null_moved && !inPV && !ss->exclude_tt_move && !ss->in_check && !board.only_pawns(board.side_to_move) && eval >= beta && ss->static_eval >= beta - 20 * depth + 200)
     {
         int r = std::min((eval - beta) / 200, 6) + depth / 3 + 4;
 


### PR DESCRIPTION
Elo   | 7.62 +- 3.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8842 W: 2206 L: 2012 D: 4624
Penta | [37, 947, 2259, 1141, 37]
https://chess.aronpetkovski.com/test/3371/

BENCH: 3295378