### PR TITLE
capthist lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -450,11 +450,18 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
         }
 
         const uint64_t nodes_before_search = nodes;
+        int64_t history_score = 0;
 
         if (is_quiet)
+        {
             quiet_moves.insert(curr_move);
+            history_score = get_quiet_history_score(ss, thread_data, curr_move);
+        }
         else if (!curr_move.is_promotion())
+        {
             noises.insert(curr_move);
+            history_score = thread_data.capthist.move_value(board, curr_move);
+        }
 
         int new_depth = depth - 1;
         int extensions = 0;
@@ -547,8 +554,7 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
         if (!improving)
             ++reduction;
 
-        if (is_quiet)
-            reduction -= get_quiet_history_score(ss, thread_data, curr_move) / 10'000;
+        reduction -= history_score / 10'000;
 
         if (inPV)
             reduction -= 1;


### PR DESCRIPTION
Elo   | 2.81 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29952 W: 7200 L: 6958 D: 15794
Penta | [96, 3544, 7478, 3738, 120]
https://chess.aronpetkovski.com/test/3444/

BENCH: 3528149