### PR TITLE
Use MVV instead of LVA 

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -64,11 +64,10 @@ void MovePicker::score(SearchStack *ss, ThreadData &thread_data, Move tt_move, b
                 continue;
             }
 
-            uint8_t source_square = curr_move.from_square();
             uint8_t target_square = curr_move.to_square();
 
             // use mvv to find the move value
-            int captured_piece_value = mvv_values[ss->board.mailbox[source_square]];
+            int captured_piece_value = mvv_values[ss->board.mailbox[target_square]];
 
             // apply a promotion bonus if necessary
             int promotion_piece_value = 0;


### PR DESCRIPTION
Elo   | 1.35 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 24490 W: 5898 L: 5803 D: 12789
Penta | [92, 2923, 6118, 3022, 90]
https://chess.aronpetkovski.com/test/3636/

BENCH: 3109595