### PR TITLE
Promo capthist2

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -77,9 +77,9 @@ void MovePicker::score(SearchStack *ss, ThreadData &thread_data, Move tt_move, b
 
                 // if the piece is a queen or a knight, we apply it's promotion value
                 if (promotion_piece == BITBOARD_PIECES::QUEEN)
-                    promotion_piece_value = mvv_values[PIECES::WHITE_QUEEN] + PROMOTION_BONUS;
+                    promotion_piece_value = mvv_values[PIECES::WHITE_QUEEN];
                 else if (promotion_piece == BITBOARD_PIECES::KNIGHT)
-                    promotion_piece_value = mvv_values[PIECES::WHITE_KNIGHT] + PROMOTION_BONUS;
+                    promotion_piece_value = mvv_values[PIECES::WHITE_KNIGHT];
             }
 
             curr_move.score += captured_piece_value + promotion_piece_value + (SEE(ss->board, move_list.moves[i], threshold) ? CAPTURE_BONUS : -CAPTURE_BONUS);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -476,7 +476,7 @@ int Searcher::negamax(int alpha, int beta, int depth, bool cutnode, SearchStack 
             quiet_moves.insert(curr_move);
             history_score = get_quiet_history_score(ss, thread_data, curr_move);
         }
-        else if (!curr_move.is_promotion())
+        else
         {
             noises.insert(curr_move);
             history_score = thread_data.capthist.move_value(board, curr_move);


### PR DESCRIPTION
Elo   | 2.49 +- 2.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 15096 W: 3613 L: 3505 D: 7978
Penta | [58, 1703, 3932, 1783, 72]
https://chess.aronpetkovski.com/test/3813/

BENCH: 2914563