### PR TITLE
Fixed En-passant bug

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -77,7 +77,7 @@ public:
     void remove_piece(uint8_t square);
 
     // no error checking, call before making move
-    uint8_t captured_piece(Move move) { return mailbox[move.to_square()]; }
+    uint8_t captured_piece(Move move) { return move.move_flag() == MOVE_FLAG::EN_PASSANT_CAPTURE ? BITBOARD_PIECES::PAWN : mailbox[move.to_square()]; }
 
     // no error check, call before making move
     uint8_t moving_piece(Move move) { return mailbox[move.from_square()]; }


### PR DESCRIPTION
```Elo   | -0.24 +- 0.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 159852 W: 37411 L: 37522 D: 84919
Penta | [1042, 19030, 39837, 19031, 986]```
<https://chess.aronpetkovski.com/test/7668/>

bench: 2883426